### PR TITLE
Fix a typo causing my post to be incorrectly categorized

### DIFF
--- a/en/_posts/2014-10-13-how-to-install-jenkins-on-runabove.markdown
+++ b/en/_posts/2014-10-13-how-to-install-jenkins-on-runabove.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: How to install Jenkins on RunAbove?
-catagories: instances
+categories: instances
 tags: guide
 author: DrOfAwesomeness
 lang: en


### PR DESCRIPTION
In my Jenkins post I had misspelled "categories" in the front matter, causing it to be published without a category (oops.) Sorry about that, here's a fix.
