### PR TITLE
New Post: How to install Gitlab CE on RunAbove

### DIFF
--- a/en/_posts/2014-10-16-how-to-install-gitlab.md
+++ b/en/_posts/2014-10-16-how-to-install-gitlab.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "How to install Gitlab CE on RunAbove"
+title: "How to install Gitlab on Ubuntu 14.04"
 categories: Instances
 author: DrOfAwesomeness
 lang: en


### PR DESCRIPTION
I wrote a post about installing the [Community Edition](https://about.gitlab.com/gitlab-ce/) of Gitlab on RunAbove. Gitlab CE is basically a MIT-licensed self-hosted Github, so I think this fits well with RunAbove's developer community.
