### PR TITLE
Typos and minor upgrades

### DIFF
--- a/en/_posts/2014-09-29-getting-started-with-sailabove-docker.markdown
+++ b/en/_posts/2014-09-29-getting-started-with-sailabove-docker.markdown
@@ -7,7 +7,7 @@ lang: en
 author: yadutaf
 ---
 
-Sailabove elgantly hosts and runs "Docker(tm)" based applications in a RunAbove(tm) cloud. If you've never heard of Docker (yet), it's the buzzing solution that not only promise but actually makes it possible to say:
+Sailabove elegantly hosts and runs Docker(tm) based applications in a RunAbove(tm) cloud. If you've never heard of Docker (yet), it's the buzzing solution that not only promises but actually makes it possible to say:
 
     "If it works on dev, it works on production"
 
@@ -17,11 +17,11 @@ Overview
 Docker
 ------
 
-[Docker](https://www.docker.com/) is a buzzing *container* solution. Just like shiping containers are standard "boxes" to send anything anywhere, Dockers are standard application containers based on Linux to build and run code anywhere.
+[Docker](https://www.docker.com/) is a buzzing *container* solution. Just like shipping containers are standard "boxes" to send anything anywhere, Dockers are standard application containers based on Linux to build and run code anywhere.
 
 It can be seen as a VM running a single service while being much faster and lighter than an actual Virtual Machine.
 
-Additionaly, Docker introduces the notion of *links*. Docker links mechanism is used to logically attach related containers together. For example, to link a blog like wordpress to its database.
+Additionally, Docker introduces the notion of *links*. Docker links mechanism is used to logically attach related containers together. For example, to link a blog like wordpress to its database.
 
 Want to learn more about Docker ? [Visit Docker's official presentation page.](https://docker.com/whatisdocker/)
 
@@ -30,7 +30,7 @@ Sailabove
 
 Sailabove can host and scale any Docker application. It is:
 
-- **Flexible as a dedicated server**: You can use any lib or sofwtware you want, as long as it runs on 64bit Linux. Be it written in Java (OpenTsdb), Python (Django), Ruby (Gitlab), Go (InfluxDB), C (HaProxy, Redis, MariaDB), ... That's pretty much any server side software!
+- **Flexible as a dedicated server**: You can use any lib or software you want, as long as it runs on 64bit Linux. Be it written in Java (OpenTsdb), Python (Django), Ruby (Gitlab), Go (InfluxDB), C (HaProxy, Redis, MariaDB), ... That's pretty much any server side software!
 - **Powerful as a cluster**: Easily scale any individual application component and feel as if it was all on a single server.
 - **Simple as shared hosting**: We do the hard work of keeping the servers up, monitoring and scaling your application, ...
 
@@ -45,7 +45,7 @@ Docker applications are built using 2 core concepts:
 Additionally, Sailabove introduces 1 more concept:
 - services: scalable group of 1 to N identical containers.
 
-Individual containers can be scaled to N identical instances forming a service. Services (hence containers) can be linked together to form a full N-Tier application. For instance, a Wordpress container would be linked to a MariaDB database and maybe a HaProxy caching frontend.
+Individual containers can be scaled to N identical instances forming a service. Services (hence containers) can be linked together to form a full N-Tier application. For instance, a Wordpress container would be linked to a MariaDB database and maybe a HaProxy caching front end.
 
 Getting Started
 ===============
@@ -57,16 +57,16 @@ Visit https://labs.runabove.com/sail/ and sign-up using your *Free* [Runabove Ac
 
 Once authenticated, choose your docker's username and password. You'll need them to push and run your docker images. You'll then be directed to the welcome page. You should also receive a confirmation email.
 
-When comming back, use the same method to authenticate, you'll be automatically directed directly to the welcome page.
+When coming back, use the same method to authenticate, you'll be automatically directed to the welcome page.
 
 2. Setup your Docker
 --------------------
 
-If needed, install first the official Docker client. An exhaustive documentation for a variety of Operating Systems including Ubuntu, Windows and MacOS X is available on Docker official website: https://docs.docker.com/installation/#installation
+If needed, install the official Docker client. An exhaustive documentation for a variety of Operating Systems including Ubuntu, Windows and MacOS X is available on Docker official website: https://docs.docker.com/installation/#installation
 
 Fire up a terminal, (Application > Utilities > Terminal on Mac OS X; Usually <Ctrl>+<Alt>+T on Linux). Windows is not officially supported (yet).
 
-Then login, using the credentials you just created (e-mail address is not required):
+Then login, using the credentials you just created (email address is not required):
 ```bash
 docker login sailabove.io
 ```

--- a/en/_posts/2014-09-29-hello-go.markdown
+++ b/en/_posts/2014-09-29-hello-go.markdown
@@ -7,11 +7,11 @@ lang: en
 author: yadutaf
 ---
 
-[Go](http://golang.org/) is quite recent, modern, high performance langage developped by Google. It emphases on security, performance and concurrent execution. It first ficused on system development like C and C++ while bringing a leaner and richer syntax. In became a prominent technology in just a few months. Before Docker, it was the first langage to bring a solution to the dependency hell as it links statically all its dependencies by default.
+[Go](http://golang.org/) is quite recent, modern, high performance language developed by Google. It emphases on security, performance and concurrent execution. It first focused on system development like C and C++ while bringing a leaner and richer syntax. In became a prominent technology in just a few months. Before Docker, it was the first language to bring a solution to the dependency hell as it links statically all its dependencies by default.
 
 To just give a taste of how powerful it is: this is the technology behind Docker itself!
 
-Even though it is still a young project, it already have a [huge standard and contributed library](http://golang.org/pkg/) thanks to its huge community of enthousiast. Moreover, any project, from any standard versioning system (Git, Mercurial, SVN) can be installed as a package, directly from the repo.
+Even though it is still a young project, it already have a [huge standard and contributed library](http://golang.org/pkg/) thanks to its huge community of enthusiast. Moreover, any project, from any standard versioning system (Git, Mercurial, SVN) can be installed as a package, directly from the repository.
 
 Before diving in, make sure to read the [Getting Started](getting-started-with-sailabove-docker.html) guide.
 
@@ -73,9 +73,9 @@ docker build -t hello-go .
 docker run -it --publish 8080:80 --rm -t hello-go
 ```
 
-Check if all works fine, visit http://localhost:8080/hello/Docker-Fan. You should see womething like "Hello Docker-Fan!".
+Check if all works fine, visit http://localhost:8080/hello/Docker-Fan. You should see something like "Hello Docker-Fan!".
 
-It works on your dev machine. It will work on production.
+It works on your development machine. It will work on production.
 
 3. Go live!
 ===========
@@ -94,11 +94,11 @@ Push your application on Sailabove's *private* Docker registry:
 docker push sailabove.io/demo/hello-go
 ```
 
-Launch it using previously installed ``sail`` command line and instruct Sailabove to run it with unpriviledged user ``nobody`` for increased security. Please note that, even when running as regular unprivileged user, your application can freely listen on *any* port, ``80`` in this case.
+Launch it using previously installed ``sail`` command line and instruct Sailabove to run it with unprivileged user ``nobody`` for increased security. Please note that, even when running as regular unprivileged user, your application can freely listen on *any* port, ``80`` in this case.
 
 ```bash
 # sail services add <user name>/<app name> <service name>
-sail services add demo/hello-go hello-go --user nobody
+sail services add demo/hello-go hello-go
 ```
 
 Eager to see the result? Wait a few seconds. It is now running live on http://hello-go.demo.app.sailabove.io/hello/Docker-Fan. This is ``http://<service name>.<user name>.app.sailabove.io``.

--- a/en/_posts/2014-09-29-hello-node.markdown
+++ b/en/_posts/2014-09-29-hello-node.markdown
@@ -7,7 +7,7 @@ lang: en
 author: yadutaf
 ---
 
-[Node.js](http://nodejs.org/) is modern event-based asynchronous langage built on the foundations of the lighning fast ``V8`` javascript engine powering Google Chrome. Its event based approach contributed a lot to its popularity. It helps a lot to built fast, scalable and efficient IO bound applications.
+[Node.js](http://nodejs.org/) is modern event-based asynchronous language built on the foundations of the lighting fast ``V8`` javascript engine powering Google Chrome. Its event based approach contributed a lot to its popularity. It helps a lot to built fast, scalable and efficient IO bound applications.
 
 Node.js comes with a [large library of packages](https://www.npmjs.org/) installable using ``npm install``.
 
@@ -74,7 +74,7 @@ FROM node:0.10-onbuild
 EXPOSE 80
 ```
 
-It first instructs Docker to get Node.js ``0.10`` base image with automatic build support (``-onbuild``). To use another Node.js runtime version like the beeding edge one, you may choose to use ``FROM node:0.11-onbuild`` for instance.
+It first instructs Docker to get Node.js ``0.10`` base image with automatic build support (``-onbuild``). To use another Node.js runtime version like the bleeding edge one, you may choose to use ``FROM node:0.11-onbuild`` for instance.
 
 We then declare the ``PORT`` our application will listen on. In our case, standard HTTP port.
 
@@ -86,7 +86,7 @@ docker build -t hello-node .
 docker run -it --publish 8080:80 --rm -t hello-node
 ```
 
-Check if all works fine, visit http://localhost:8080/hello/Docker-Fan. You should see womething like "Hello Docker-Fan!".
+Check if all works fine, visit http://localhost:8080/hello/Docker-Fan. You should see something like "Hello Docker-Fan!".
 
 It works on your dev machine. It will work on production.
 
@@ -107,11 +107,11 @@ Push your application on Sailabove's *private* Docker registry:
 docker push sailabove.io/demo/hello-node
 ```
 
-Launch it using previously installed ``sail`` command line and instruct Sailabove to run it with unpriviledged user ``nobody`` for increased security. Please note that, even when running as regular unprivileged user, your application can freely listen on *any* port, ``80`` in this case.
+Launch it using previously installed ``sail`` command line and instruct Sailabove to run it with unprivileged user ``nobody`` for increased security. Please note that, even when running as regular unprivileged user, your application can freely listen on *any* port, ``80`` in this case.
 
 ```bash
 # sail services add <user name>/<app name> <service name>
-sail services add demo/hello-node hello-node --user nobody
+sail services add demo/hello-node hello-node
 ```
 
 Eager to see the result? Wait a few seconds. It is now running live on http://hello-node.demo.app.sailabove.io/hello/Docker-Fan. This is ``http://<service name>.<user name>.app.sailabove.io``.

--- a/en/_posts/2014-09-29-hello-python.markdown
+++ b/en/_posts/2014-09-29-hello-python.markdown
@@ -7,7 +7,7 @@ lang: en
 author: yadutaf
 ---
 
-[Python](https://www.python.org/) is a very popular and well established interpreted language. It emphases on code read readability and brings all the features one would expect from a modern langage like dynamic typing, object programming, automatic memory managment, ...
+[Python](https://www.python.org/) is a very popular and well established interpreted language. It emphases on code read readability and brings all the features one would expect from a modern language like dynamic typing, object programming, automatic memory management, ...
 
 Python comes with a [huge library of packages](https://pypi.python.org/pypi) installable using ``pip install``.
 
@@ -68,7 +68,7 @@ docker build -t hello-python .
 docker run -it --publish 8080:80 --rm -t hello-python
 ```
 
-Check if all works fine, visit http://localhost:8080/hello/Docker-Fan. You should see womething like "Hello Docker-Fan!".
+Check if all works fine, visit http://localhost:8080/hello/Docker-Fan. You should see something like "Hello Docker-Fan!".
 
 It works on your dev machine. It will work on production.
 
@@ -89,11 +89,11 @@ Push your application on Sailabove's *private* Docker registry:
 docker push sailabove.io/demo/hello-python
 ```
 
-Launch it using previously installed ``sail`` command line and instruct Sailabove to run it with unpriviledged user ``nobody`` for increased security. Please note that, even when running as regular unprivileged user, your application can freely listen on *any* port, ``80`` in this case.
+Launch it using previously installed ``sail`` command line and instruct Sailabove to run it with unprivileged user ``nobody`` for increased security. Please note that, even when running as regular unprivileged user, your application can freely listen on *any* port, ``80`` in this case.
 
 ```bash
 # sail services add <user name>/<app name> <service name>
-sail services add demo/hello-python hello-python --user nobody
+sail services add demo/hello-python hello-python
 ```
 
 Eager to see the result? Wait a few seconds. It is now running live on http://hello-python.demo.app.sailabove.io/hello/Docker-Fan. This is ``http://<service name>.<user name>.app.sailabove.io``.

--- a/en/_posts/2014-09-29-hello-ruby.markdown
+++ b/en/_posts/2014-09-29-hello-ruby.markdown
@@ -11,7 +11,7 @@ author: yadutaf
 
 Ruby comes with a [huge library of "Gems"](https://rubygems.org/) installable using ``gem install``.
 
-But Ruby would have probably never gotten so famous without [Ruby on Rails](http://rubyonrails.org/), a full featured web framework that inspired many others. And that's not the only one. There is also [Sinatra](http://www.sinatrarb.com/), a lightweith micro-framework. Ruby is also the foundation of [Gitlab](https://about.gitlab.com/), the leading OpenSource GitHub alternative.
+But Ruby would have probably never gotten so famous without [Ruby on Rails](http://rubyonrails.org/), a full featured web framework that inspired many others. And that's not the only one. There is also [Sinatra](http://www.sinatrarb.com/), a lightweight micro-framework. Ruby is also the foundation of [Gitlab](https://about.gitlab.com/), the leading OpenSource GitHub alternative.
 
 Before diving in, make sure to read the [Getting Started](getting-started-with-sailabove-docker.html) guide.
 
@@ -69,7 +69,7 @@ docker build -t hello-ruby .
 docker run -it --publish 8080:80 --rm -t hello-ruby
 ```
 
-Check if all works fine, visit http://localhost:8080/hello/Docker-Fan. You should see womething like "Hello Docker-Fan!".
+Check if all works fine, visit http://localhost:8080/hello/Docker-Fan. You should see something like "Hello Docker-Fan!".
 
 It works on your dev machine. It will work on production.
 
@@ -90,11 +90,11 @@ Push your application on Sailabove's *private* Docker registry:
 docker push sailabove.io/demo/hello-ruby
 ```
 
-Launch it using previously installed ``sail`` command line and instruct Sailabove to run it with unpriviledged user ``nobody`` for increased security. Please note that, even when running as regular unprivileged user, your application can freely listen on *any* port, ``80`` in this case.
+Launch it using previously installed ``sail`` command line and instruct Sailabove to run it with unprivileged user ``nobody`` for increased security. Please note that, even when running as regular unprivileged user, your application can freely listen on *any* port, ``80`` in this case.
 
 ```bash
 # sail services add <user name>/<app name> <service name>
-sail services add demo/hello-ruby hello-ruby --user nobody
+sail services add demo/hello-ruby hello-ruby
 ```
 
 Eager to see the result? Wait a few seconds. It is now running live on http://hello-ruby.demo.app.sailabove.io/hello/Docker-Fan. This is ``http://<service name>.<user name>.app.sailabove.io``.


### PR DESCRIPTION
There were a couple of typos in Sailabove's guide. This PR addresses the bulk of them. One of the command line parameter previously used is now optional and has been removed from the documentation for the sake of simplicity.
