### PR TITLE
Added hint for old kernels.

### DIFF
--- a/en/_posts/2015-01-29-attach-volume.md
+++ b/en/_posts/2015-01-29-attach-volume.md
@@ -47,6 +47,8 @@ instances.
 
 ### GNU/Linux
 
+> Before doing the following, please be sure that modules *acpiphp* and *pci_hotplug* are loaded (*modprobe acpiphp* && *modprobe pci_hotplug*)
+
 From a shell issue the `lsblk` command, this will list the block devices you 
 can use:
 


### PR DESCRIPTION
Sometime we need to use mod probe to load modules to be able to add a disk.